### PR TITLE
Avoid the level up menu on the host hanging the server

### DIFF
--- a/Always On Server/ModEntry.cs
+++ b/Always On Server/ModEntry.cs
@@ -722,6 +722,17 @@ namespace Always_On_Server
                         this.LeaveFestival();
                 }
             }
+
+            // Skip level up menu
+            if (IsAutomating && Game1.activeClickableMenu is LevelUpMenu)
+            {
+                // Taken from LevelUpMenu.cs:504
+                this.Monitor.Log("Skipping level up menu");
+                ((LevelUpMenu)Game1.activeClickableMenu).isActive = false;
+                ((LevelUpMenu)Game1.activeClickableMenu).informationUp = false;
+                ((LevelUpMenu)Game1.activeClickableMenu).isProfessionChooser = false;
+                ((LevelUpMenu)Game1.activeClickableMenu).RemoveLevelFromLevelList();
+            }
         }
 
         //Pause game if no clients Code


### PR DESCRIPTION
This isn't skipped when it pops up, so it'll hang the server waiting for the host.

![image](https://user-images.githubusercontent.com/564860/79686679-844b2580-8285-11ea-80be-40d32ee84651.png)

Instead of someone having to log in and manually dismiss it, we just check if it's displayed and skip it automatically.